### PR TITLE
Infer @SingleValueResult for Optional return types

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/sqlobject/ResultReturnThing.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/ResultReturnThing.java
@@ -85,16 +85,15 @@ abstract class ResultReturnThing
                 SingleValueResult svr = method.getRawMember().getAnnotation(SingleValueResult.class);
                 // try to guess generic type
                 if(SingleValueResult.Default.class == svr.value()){
-                    TypeBindings typeBindings = method.getReturnType().getTypeBindings();
-                    if(typeBindings.size() == 1){
-                        this.returnType = typeBindings.getBoundType(0).getErasedType();
-                    }else{
-                        throw new IllegalArgumentException("Ambiguous generic information. SingleValueResult type could not be fetched.");
-                    }
-
+                    this.returnType = getSingleBoundReturnType(method);
                 }else{
                     this.returnType = svr.value();
                 }
+                this.containerType = method.getReturnType().getErasedType();
+            } else if (method.getReturnType().getErasedType().getName().equals("java.util.Optional")
+                    || method.getReturnType().getErasedType().getName().equals("com.google.common.base.Optional")
+            ) {
+                this.returnType = getSingleBoundReturnType(method);
                 this.containerType = method.getReturnType().getErasedType();
             }
             else {
@@ -102,6 +101,15 @@ abstract class ResultReturnThing
                 this.containerType = null;
             }
 
+        }
+
+        private static Class<?> getSingleBoundReturnType(ResolvedMethod method) {
+            TypeBindings typeBindings = method.getReturnType().getTypeBindings();
+            if(typeBindings.size() == 1){
+                 return typeBindings.getBoundType(0).getErasedType();
+            }else{
+                throw new IllegalArgumentException("Ambiguous generic information. SingleValueResult type could not be fetched.");
+            }
         }
 
         @Override


### PR DESCRIPTION
Adding this annotation is mostly annoying and it shouldn't really be necessary.

There a few potential issues I see with this PR:
- It relies on there being `Container` factories for `java.util.Optional` and `com.google.common.base.Optional`
- It's  a bit larger than we might want a change to a forked open-source to be

@jhaber 
/cc @solomonty 