### PR TITLE
add getters for binding parameters

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/Binding.java
+++ b/src/main/java/org/skife/jdbi/v2/Binding.java
@@ -17,6 +17,7 @@ import org.skife.jdbi.v2.tweak.Argument;
 import org.skife.jdbi.v2.tweak.NamedArgumentFinder;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -113,6 +114,18 @@ public class Binding
 
         b.append("}");
         return b.toString();
+    }
+
+    public Map<Integer, Argument> getPositionalArguments() {
+        return Collections.unmodifiableMap(positionals);
+    }
+
+    public Map<String, Argument> getNamedArguments() {
+        return Collections.unmodifiableMap(named);
+    }
+
+    public List<NamedArgumentFinder> getNamedArgumentFinders() {
+        return Collections.unmodifiableList(namedArgumentFinder);
     }
 
     public void clear()


### PR DESCRIPTION
Allows us to access the bound arguments directly inside a statement rewriter

@jhaber 