### PR TITLE
Don't allow @Define on strings

### DIFF
--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestOverrideStatementLocatorWith.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestOverrideStatementLocatorWith.java
@@ -13,6 +13,11 @@
  */
 package org.skife.jdbi.v2.sqlobject;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.UUID;
+
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.After;
 import org.junit.Before;
@@ -25,13 +30,16 @@ import org.skife.jdbi.v2.sqlobject.customizers.OverrideStatementLocatorWith;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.StringTemplate3StatementLocator;
 
-import java.util.UUID;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
-
 public class TestOverrideStatementLocatorWith
 {
+    private enum Table {
+        something
+    }
+
+    private enum Column {
+        id, name
+    }
+
     private Handle handle;
 
     @Before
@@ -85,7 +93,7 @@ public class TestOverrideStatementLocatorWith
     @Test
     public void testDefines() throws Exception
     {
-        handle.attach(Kangaroo.class).weirdInsert("something", "id", "name", 5, "Bouncer");
+        handle.attach(Kangaroo.class).weirdInsert(Table.something, Column.id, Column.name, 5, "Bouncer");
         String name = handle.createQuery("select name from something where id = 5")
                             .mapTo(String.class)
                             .first();
@@ -108,9 +116,9 @@ public class TestOverrideStatementLocatorWith
         String findNameFor(@Bind int id);
 
         @SqlUpdate
-        void weirdInsert(@Define("table") String table,
-                         @Define("id_column") String idColumn,
-                         @Define("value_column") String valueColumn,
+        void weirdInsert(@Define("table") Table table,
+                         @Define("id_column") Column idColumn,
+                         @Define("value_column") Column valueColumn,
                          @Bind("id") int id,
                          @Bind("value") String name);
     }

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestStringTemplate3Locator.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestStringTemplate3Locator.java
@@ -31,14 +31,6 @@ import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLoc
 
 public class TestStringTemplate3Locator
 {
-    private enum Table {
-        something
-    }
-
-    private enum Column {
-        id, name
-    }
-
     private Handle handle;
 
     @Before
@@ -90,8 +82,8 @@ public class TestStringTemplate3Locator
     @Test
     public void testDefines() throws Exception
     {
-        handle.attach(Wombat.class).weirdInsert(Table.something, Column.id, Column.name, 5, "Bouncer");
-        handle.attach(Wombat.class).weirdInsert(Table.something, Column.id, Column.name, 6, "Bean");
+        handle.attach(Wombat.class).weirdInsert("something", "id", "name", 5, "Bouncer");
+        handle.attach(Wombat.class).weirdInsert("something", "id", "name", 6, "Bean");
         String name = handle.createQuery("select name from something where id = 5")
                             .mapTo(String.class)
                             .first();
@@ -115,8 +107,8 @@ public class TestStringTemplate3Locator
     {
         HoneyBadger badass = handle.attach(HoneyBadger.class);
 
-        badass.insert(Table.something, new Something(1, "Ted"));
-        badass.insert(Table.something, new Something(2, "Fred"));
+        badass.insert("something", new Something(1, "Ted"));
+        badass.insert("something", new Something(2, "Fred"));
     }
 
     @UseStringTemplate3StatementLocator
@@ -124,10 +116,10 @@ public class TestStringTemplate3Locator
     static interface HoneyBadger
     {
         @SqlUpdate("insert into <table> (id, name) values (:id, :name)")
-        public void insert(@Define("table") Table table, @BindBean Something s);
+        public void insert(@Define("table") String table, @BindBean Something s);
 
         @SqlQuery("select id, name from <table> where id = :id")
-        public Something findById(@Define("table") Table table, @Bind("id") Long id);
+        public Something findById(@Define("table") String table, @Bind("id") Long id);
     }
 
     @ExternalizedSqlViaStringTemplate3
@@ -144,9 +136,9 @@ public class TestStringTemplate3Locator
         String findNameFor(@Bind int id);
 
         @SqlUpdate
-        void weirdInsert(@Define("table") Table table,
-                         @Define("id_column") Column idColumn,
-                         @Define("value_column") Column valueColumn,
+        void weirdInsert(@Define("table") String table,
+                         @Define("id_column") String idColumn,
+                         @Define("value_column") String valueColumn,
                          @Bind("id") int id,
                          @Bind("value") String name);
 

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestStringTemplate3Locator.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestStringTemplate3Locator.java
@@ -13,6 +13,11 @@
  */
 package org.skife.jdbi.v2.sqlobject;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.UUID;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,13 +29,16 @@ import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.ExternalizedSqlViaStringTemplate3;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
 
-import java.util.UUID;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
-
 public class TestStringTemplate3Locator
 {
+    private enum Table {
+        something
+    }
+
+    private enum Column {
+        id, name
+    }
+
     private Handle handle;
 
     @Before
@@ -82,8 +90,8 @@ public class TestStringTemplate3Locator
     @Test
     public void testDefines() throws Exception
     {
-        handle.attach(Wombat.class).weirdInsert("something", "id", "name", 5, "Bouncer");
-        handle.attach(Wombat.class).weirdInsert("something", "id", "name", 6, "Bean");
+        handle.attach(Wombat.class).weirdInsert(Table.something, Column.id, Column.name, 5, "Bouncer");
+        handle.attach(Wombat.class).weirdInsert(Table.something, Column.id, Column.name, 6, "Bean");
         String name = handle.createQuery("select name from something where id = 5")
                             .mapTo(String.class)
                             .first();
@@ -107,8 +115,8 @@ public class TestStringTemplate3Locator
     {
         HoneyBadger badass = handle.attach(HoneyBadger.class);
 
-        badass.insert("something", new Something(1, "Ted"));
-        badass.insert("something", new Something(2, "Fred"));
+        badass.insert(Table.something, new Something(1, "Ted"));
+        badass.insert(Table.something, new Something(2, "Fred"));
     }
 
     @UseStringTemplate3StatementLocator
@@ -116,10 +124,10 @@ public class TestStringTemplate3Locator
     static interface HoneyBadger
     {
         @SqlUpdate("insert into <table> (id, name) values (:id, :name)")
-        public void insert(@Define("table") String table, @BindBean Something s);
+        public void insert(@Define("table") Table table, @BindBean Something s);
 
         @SqlQuery("select id, name from <table> where id = :id")
-        public Something findById(@Define("table") String table, @Bind("id") Long id);
+        public Something findById(@Define("table") Table table, @Bind("id") Long id);
     }
 
     @ExternalizedSqlViaStringTemplate3
@@ -136,9 +144,9 @@ public class TestStringTemplate3Locator
         String findNameFor(@Bind int id);
 
         @SqlUpdate
-        void weirdInsert(@Define("table") String table,
-                         @Define("id_column") String idColumn,
-                         @Define("value_column") String valueColumn,
+        void weirdInsert(@Define("table") Table table,
+                         @Define("id_column") Column idColumn,
+                         @Define("value_column") Column valueColumn,
                          @Bind("id") int id,
                          @Bind("value") String name);
 

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestStringTemplate3Locator.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestStringTemplate3Locator.java
@@ -39,13 +39,13 @@ public class TestStringTemplate3Locator
         DBI dbi = new DBI("jdbc:h2:mem:" + UUID.randomUUID());
         handle = dbi.open();
 
-        handle.execute("create table something (id int primary key, name varchar(100))");
+        handle.execute("create table SOMETHING (ID int primary key, NAME varchar(100))");
     }
 
     @After
     public void tearDown() throws Exception
     {
-        handle.execute("drop table something");
+        handle.execute("drop table SOMETHING");
         handle.close();
     }
 
@@ -55,7 +55,7 @@ public class TestStringTemplate3Locator
         Wombat wombat = handle.attach(Wombat.class);
         wombat.insert(new Something(7, "Henning"));
 
-        String name = handle.createQuery("select name from something where id = 7")
+        String name = handle.createQuery("select NAME from SOMETHING where ID = 7")
                             .mapTo(String.class)
                             .first();
 
@@ -65,7 +65,7 @@ public class TestStringTemplate3Locator
     @Test
     public void testBam() throws Exception
     {
-        handle.execute("insert into something (id, name) values (6, 'Martin')");
+        handle.execute("insert into SOMETHING (ID, NAME) values (6, 'Martin')");
 
         Something s = handle.attach(Wombat.class).findById(6L);
         assertThat(s.getName(), equalTo("Martin"));
@@ -74,7 +74,7 @@ public class TestStringTemplate3Locator
     @Test
     public void testBap() throws Exception
     {
-        handle.execute("insert into something (id, name) values (2, 'Bean')");
+        handle.execute("insert into SOMETHING (ID, NAME) values (2, 'Bean')");
         Wombat w = handle.attach(Wombat.class);
         assertThat(w.findNameFor(2), equalTo("Bean"));
     }
@@ -82,9 +82,9 @@ public class TestStringTemplate3Locator
     @Test
     public void testDefines() throws Exception
     {
-        handle.attach(Wombat.class).weirdInsert("something", "id", "name", 5, "Bouncer");
-        handle.attach(Wombat.class).weirdInsert("something", "id", "name", 6, "Bean");
-        String name = handle.createQuery("select name from something where id = 5")
+        handle.attach(Wombat.class).weirdInsert("SOMETHING", "ID", "NAME", 5, "Bouncer");
+        handle.attach(Wombat.class).weirdInsert("SOMETHING", "ID", "NAME", 6, "Bean");
+        String name = handle.createQuery("select NAME from SOMETHING where ID = 5")
                             .mapTo(String.class)
                             .first();
 
@@ -107,18 +107,18 @@ public class TestStringTemplate3Locator
     {
         HoneyBadger badass = handle.attach(HoneyBadger.class);
 
-        badass.insert("something", new Something(1, "Ted"));
-        badass.insert("something", new Something(2, "Fred"));
+        badass.insert("SOMETHING", new Something(1, "Ted"));
+        badass.insert("SOMETHING", new Something(2, "Fred"));
     }
 
     @UseStringTemplate3StatementLocator
     @RegisterMapper(SomethingMapper.class)
     static interface HoneyBadger
     {
-        @SqlUpdate("insert into <table> (id, name) values (:id, :name)")
+        @SqlUpdate("insert into <table> (ID, NAME) values (:id, :name)")
         public void insert(@Define("table") String table, @BindBean Something s);
 
-        @SqlQuery("select id, name from <table> where id = :id")
+        @SqlQuery("select ID, NAME from <table> where ID = :id")
         public Something findById(@Define("table") String table, @Bind("id") Long id);
     }
 
@@ -132,7 +132,7 @@ public class TestStringTemplate3Locator
         @SqlQuery
         public Something findById(@Bind("id") Long id);
 
-        @SqlQuery("select name from something where id = :it")
+        @SqlQuery("select NAME from SOMETHING where ID = :it")
         String findNameFor(@Bind int id);
 
         @SqlUpdate

--- a/src/test/resources/org/skife/jdbi/v2/sqlobject/TestStringTemplate3Locator$Wombat.sql.stg
+++ b/src/test/resources/org/skife/jdbi/v2/sqlobject/TestStringTemplate3Locator$Wombat.sql.stg
@@ -1,11 +1,11 @@
 group Wombat;
 
 kangaroo(name) ::= << hello <name> >>
-insert() ::= << insert into something (id, name) values (:id, :name) >>
-findById() ::= << select id, name from something where id = :id >>
+insert() ::= << insert into SOMETHING (ID, NAME) values (:id, :name) >>
+findById() ::= << select ID, NAME from SOMETHING where ID = :id >>
 weirdInsert(table, id_column, value_column) ::= <<
     insert into <table> (<id_column>, <value_column>) values (:id, :value)
 >>
 insertBunches() ::= <<
-    insert into something (id, name) values (:id, :name)
+    insert into SOMETHING (ID, NAME) values (:id, :name)
 >>


### PR DESCRIPTION
This requires arguments used with `@Define` to be enums or primitives