### PR TITLE
add warning when using streaming queries under (Vitess) transactions

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/FetchSize.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/FetchSize.java
@@ -92,7 +92,6 @@ public @interface FetchSize
                 public void apply(SQLStatement q) throws SQLException
                 {
                     assert q instanceof Query;
-                    logIfStreamingInTransaction(q, fs);
                     ((Query) q).setFetchSize(va);
                 }
             };

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/FetchSize.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/FetchSize.java
@@ -44,12 +44,6 @@ public @interface FetchSize
     class Factory implements SqlStatementCustomizerFactory
     {
 
-        private void logIfStreamingInTransaction(SQLStatement q, FetchSize fetchSize) throws SQLException {
-            if (fetchSize.value() > 0 && !q.getContext().getConnection().getAutoCommit()) {
-                LOG.error(VITESS_STREAMING_WARNING);
-            }
-        }
-
         @Override
         public SqlStatementCustomizer createForMethod(Annotation annotation, Class sqlObjectType, Method method)
         {
@@ -95,6 +89,12 @@ public @interface FetchSize
                     ((Query) q).setFetchSize(va);
                 }
             };
+        }
+
+        private void logIfStreamingInTransaction(SQLStatement q, FetchSize fetchSize) throws SQLException {
+            if (fetchSize.value() > 0 && !q.getContext().getConnection().getAutoCommit()) {
+                LOG.error(VITESS_STREAMING_WARNING);
+            }
         }
     }
 }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/FetchSize.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/customizers/FetchSize.java
@@ -18,8 +18,7 @@ import org.skife.jdbi.v2.SQLStatement;
 import org.skife.jdbi.v2.sqlobject.SqlStatementCustomizer;
 import org.skife.jdbi.v2.sqlobject.SqlStatementCustomizerFactory;
 import org.skife.jdbi.v2.sqlobject.SqlStatementCustomizingAnnotation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.log4j.Logger;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
@@ -34,7 +33,7 @@ import java.sql.SQLException;
 @SqlStatementCustomizingAnnotation(FetchSize.Factory.class)
 public @interface FetchSize
 {
-    Logger LOG = LoggerFactory.getLogger(FetchSize.class);
+    Logger LOG = Logger.getLogger(FetchSize.class);
 
     String VITESS_STREAMING_WARNING = "Warning: streaming reads to Vitess do not " +
         "inherit transactional context. You will not be able to read your writes.";


### PR DESCRIPTION
Under Vitess, streaming reads happen in a different connection pool than other transaction requests. This means you can't read-your-writes within an `@Transactional` method, which is an incredibly subtle bug -- short of eliminating the streaming reads pool in Vitess, we should at least warn engineers when they're running into this scenario.

You cannot execute a read-your-writes query unless `autoCommit: false` (otherwise any writes will execute immediately), so we flag any `@FetchSize(n>0)` calls running under this condition.

Also: I have no idea how to get the logging to work correctly.

@jschlather @jhaber 