### PR TITLE
Add sql batch support for long arrays

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BatchHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BatchHandler.java
@@ -70,17 +70,7 @@ class BatchHandler extends CustomizingStatementHandler
             longReturner = null;
         }
         else if (getGeneratedKeys.columnName().isEmpty()) {
-            if (getGeneratedKeys.getReturnType().equals(Integer.TYPE.getName())) {
-                integerReturner = new IntegerReturner()
-                {
-                    @Override
-                    public int[] value(PreparedBatch batch)
-                    {
-                        return toPrimitiveArray(batch.executeAndGenerateKeys(IntegerColumnMapper.PRIMITIVE).list());
-                    }
-                };
-                longReturner = null;
-            } else {
+            if (method.getReturnType().getErasedType().equals(long[].class)) {
                 longReturner = new LongReturner()
                 {
                     @Override
@@ -90,19 +80,42 @@ class BatchHandler extends CustomizingStatementHandler
                     }
                 };
                 integerReturner = null;
+            } else {
+                integerReturner = new IntegerReturner()
+                {
+                    @Override
+                    public int[] value(PreparedBatch batch)
+                    {
+                        return toPrimitiveArray(batch.executeAndGenerateKeys(IntegerColumnMapper.PRIMITIVE).list());
+                    }
+                };
+                longReturner = null;
             }
         }
         else {
-            integerReturner = new IntegerReturner()
-            {
-                @Override
-                public int[] value(PreparedBatch batch)
+            if (method.getReturnType().getErasedType().equals(long[].class)) {
+                longReturner = new LongReturner()
                 {
-                    String columnName = getGeneratedKeys.columnName();
-                    return toPrimitiveArray(batch.executeAndGenerateKeys(IntegerColumnMapper.PRIMITIVE, columnName).list());
-                }
-            };
-            longReturner = null;
+                    @Override
+                    public long[] value(PreparedBatch batch)
+                    {
+                        String columnName = getGeneratedKeys.columnName();
+                        return toPrimitiveLongArray(batch.executeAndGenerateKeys(LongColumnMapper.PRIMITIVE, columnName).list());
+                    }
+                };
+                integerReturner = null;
+            } else {
+                integerReturner = new IntegerReturner()
+                {
+                    @Override
+                    public int[] value(PreparedBatch batch)
+                    {
+                        String columnName = getGeneratedKeys.columnName();
+                        return toPrimitiveArray(batch.executeAndGenerateKeys(IntegerColumnMapper.PRIMITIVE, columnName).list());
+                    }
+                };
+                longReturner = null;
+            }
         }
     }
 

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/GetGeneratedKeys.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/GetGeneratedKeys.java
@@ -25,5 +25,6 @@ import java.lang.annotation.Target;
 public @interface GetGeneratedKeys
 {
     String columnName() default "";
+    String getReturnType() default "int";
     Class<? extends ResultSetMapper> value() default FigureItOutResultSetMapper.class;
 }

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/GetGeneratedKeys.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/GetGeneratedKeys.java
@@ -25,6 +25,5 @@ import java.lang.annotation.Target;
 public @interface GetGeneratedKeys
 {
     String columnName() default "";
-    String getReturnType() default "int";
     Class<? extends ResultSetMapper> value() default FigureItOutResultSetMapper.class;
 }

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeysHsqlDb.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeysHsqlDb.java
@@ -50,7 +50,11 @@ public class TestGetGeneratedKeysHsqlDb {
 
         @SqlBatch("insert into something (name) values (:it)")
         @GetGeneratedKeys
-        public int[] insert(@Bind List<String> names);
+        public int[] insertReturnIntArray(@Bind List<String> names);
+
+        @SqlBatch("insert into something (name) values (:it)")
+        @GetGeneratedKeys(getReturnType = "long")
+        public long[] insertReturnLongArray(@Bind List<String> names);
 
         @SqlQuery("select name from something where id = :it")
         public String findNameById(@Bind long id);
@@ -74,7 +78,7 @@ public class TestGetGeneratedKeysHsqlDb {
     {
         DAO dao = dbi.open(DAO.class);
 
-        int[] ids = dao.insert(Arrays.asList("Burt", "Macklin"));
+        int[] ids = dao.insertReturnIntArray(Arrays.asList("Burt", "Macklin"));
 
         assertThat(dao.findNameById(ids[0]), equalTo("Burt"));
         assertThat(dao.findNameById(ids[1]), equalTo("Macklin"));
@@ -82,4 +86,17 @@ public class TestGetGeneratedKeysHsqlDb {
         dao.close();
     }
 
+
+    @Test
+    public void testBatchWithLongArray() throws Exception
+    {
+        DAO dao = dbi.open(DAO.class);
+
+        long[] ids = dao.insertReturnLongArray(Arrays.asList("Burt", "Macklin"));
+
+        assertThat(dao.findNameById(ids[0]), equalTo("Burt"));
+        assertThat(dao.findNameById(ids[1]), equalTo("Macklin"));
+
+        dao.close();
+    }
 }

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeysHsqlDb.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeysHsqlDb.java
@@ -53,7 +53,7 @@ public class TestGetGeneratedKeysHsqlDb {
         public int[] insertReturnIntArray(@Bind List<String> names);
 
         @SqlBatch("insert into something (name) values (:it)")
-        @GetGeneratedKeys(getReturnType = "long")
+        @GetGeneratedKeys
         public long[] insertReturnLongArray(@Bind List<String> names);
 
         @SqlQuery("select name from something where id = :it")

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeysPostgres.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeysPostgres.java
@@ -13,6 +13,13 @@
  */
 package org.skife.jdbi.v2.sqlobject;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -21,13 +28,6 @@ import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.sqlobject.mixins.CloseMe;
 import org.skife.jdbi.v2.tweak.HandleCallback;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assume.assumeTrue;
-
-import java.util.Arrays;
-import java.util.List;
 
 public class TestGetGeneratedKeysPostgres
 {
@@ -74,6 +74,10 @@ public class TestGetGeneratedKeysPostgres
         @GetGeneratedKeys(columnName = "id")
         public int[] insert(@Bind("name") List<String> names);
 
+        @SqlBatch("insert into something (name) values (:it)")
+        @GetGeneratedKeys(getReturnType = "long")
+        public long[] insertReturnLongArray(@Bind List<String> names);
+
         @SqlQuery("select name from something where id = :it")
         public String findNameById(@Bind long id);
     }
@@ -97,6 +101,19 @@ public class TestGetGeneratedKeysPostgres
         DAO dao = dbi.open(DAO.class);
 
         int[] ids = dao.insert(Arrays.asList("Burt", "Macklin"));
+
+        assertThat(dao.findNameById(ids[0]), equalTo("Burt"));
+        assertThat(dao.findNameById(ids[1]), equalTo("Macklin"));
+
+        dao.close();
+    }
+
+    @Test
+    public void testBatchWithLongArray() throws Exception
+    {
+        TestGetGeneratedKeysHsqlDb.DAO dao = dbi.open(TestGetGeneratedKeysHsqlDb.DAO.class);
+
+        long[] ids = dao.insertReturnLongArray(Arrays.asList("Burt", "Macklin"));
 
         assertThat(dao.findNameById(ids[0]), equalTo("Burt"));
         assertThat(dao.findNameById(ids[1]), equalTo("Macklin"));

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeysPostgres.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeysPostgres.java
@@ -74,8 +74,8 @@ public class TestGetGeneratedKeysPostgres
         @GetGeneratedKeys(columnName = "id")
         public int[] insert(@Bind("name") List<String> names);
 
-        @SqlBatch("insert into something (name) values (:it)")
-        @GetGeneratedKeys(getReturnType = "long")
+        @SqlBatch("insert into something (name, id) values (:name, nextval('id_sequence'))")
+        @GetGeneratedKeys(columnName = "id")
         public long[] insertReturnLongArray(@Bind List<String> names);
 
         @SqlQuery("select name from something where id = :it")
@@ -111,7 +111,7 @@ public class TestGetGeneratedKeysPostgres
     @Test
     public void testBatchWithLongArray() throws Exception
     {
-        TestGetGeneratedKeysHsqlDb.DAO dao = dbi.open(TestGetGeneratedKeysHsqlDb.DAO.class);
+        DAO dao = dbi.open(DAO.class);
 
         long[] ids = dao.insertReturnLongArray(Arrays.asList("Burt", "Macklin"));
 


### PR DESCRIPTION
I recently ran into the issue of not being able to use SqlBatch with long ids. This seemed to be a common problem so I decided I would make an attempt at adding this functionality to jdbi. I am sure this is not the best way to do this, and am looking for input on how better to achieve this goal because I think this would be really useful functionality to have. 

I hope this PR will be used as a starting point to add this functionality! Thanks!