### PR TITLE
Add sql batch support for returning long array of ids

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,7 @@
                         <header>${project.basedir}/src/build/LICENSE-HEADER.txt</header>
                         <excludes combine.children="append">
                             <exclude>**/*.stg</exclude>
+                            <exclude>pom.xml</exclude>
                         </excludes>
                     </configuration>
                 </plugin>

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BatchHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BatchHandler.java
@@ -31,8 +31,9 @@ import org.skife.jdbi.v2.TransactionCallback;
 import org.skife.jdbi.v2.TransactionStatus;
 import org.skife.jdbi.v2.exceptions.UnableToCreateSqlObjectException;
 import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
+import org.skife.jdbi.v2.sqlobject.batch.BatchAccumulator;
+import org.skife.jdbi.v2.sqlobject.batch.BatchReturner;
 import org.skife.jdbi.v2.sqlobject.customizers.BatchChunkSize;
-import org.skife.jdbi.v2.util.IntegerColumnMapper;
 
 import com.fasterxml.classmate.members.ResolvedMethod;
 
@@ -43,7 +44,7 @@ class BatchHandler extends CustomizingStatementHandler
     private final String  sql;
     private final boolean transactional;
     private final ChunkSizeFunction batchChunkSize;
-    private final Returner returner;
+    private final BatchReturner<?> batchReturner;
 
     BatchHandler(Class<?> sqlObjectType, ResolvedMethod method)
     {
@@ -56,37 +57,17 @@ class BatchHandler extends CustomizingStatementHandler
         this.sql = SqlObject.getSql(anno, raw_method);
         this.transactional = anno.transactional();
         this.batchChunkSize = determineBatchChunkSize(sqlObjectType, raw_method);
-        final GetGeneratedKeys getGeneratedKeys = raw_method.getAnnotation(GetGeneratedKeys.class);
+        this.batchReturner = newBatchReturner(method);
+    }
+
+    private static BatchReturner<?> newBatchReturner(ResolvedMethod method) {
+        GetGeneratedKeys getGeneratedKeys = method.getRawMember().getAnnotation(GetGeneratedKeys.class);
         if (getGeneratedKeys == null) {
-            returner = new Returner()
-            {
-                @Override
-                public int[] value(PreparedBatch batch)
-                {
-                    return batch.execute();
-                }
-            };
-        }
-        else if (getGeneratedKeys.columnName().isEmpty()) {
-            returner = new Returner()
-            {
-                @Override
-                public int[] value(PreparedBatch batch)
-                {
-                    return toPrimitiveArray(batch.executeAndGenerateKeys(IntegerColumnMapper.PRIMITIVE).list());
-                }
-            };
-        }
-        else {
-            returner = new Returner()
-            {
-                @Override
-                public int[] value(PreparedBatch batch)
-                {
-                    String columnName = getGeneratedKeys.columnName();
-                    return toPrimitiveArray(batch.executeAndGenerateKeys(IntegerColumnMapper.PRIMITIVE, columnName).list());
-                }
-            };
+            return BatchReturner.newIntArrayReturner();
+        } else if (method.getReturnType().getErasedType().equals(int[].class)) {
+            return BatchReturner.newGeneratedIntReturner(getGeneratedKeys.columnName());
+        } else {
+            return BatchReturner.newGeneratedLongReturner(getGeneratedKeys.columnName());
         }
     }
 
@@ -181,7 +162,7 @@ class BatchHandler extends CustomizingStatementHandler
         }
 
         int processed = 0;
-        List<int[]> rs_parts = new ArrayList<int[]>();
+        BatchAccumulator batchAccumulator = batchReturner.newAccumulator();
 
         PreparedBatch batch = handle.prepareBatch(sql);
         populateSqlObjectData((ConcreteStatementContext) batch.getContext());
@@ -196,7 +177,7 @@ class BatchHandler extends CustomizingStatementHandler
             if (++processed == chunk_size) {
                 // execute this chunk
                 processed = 0;
-                rs_parts.add(executeBatch(handle, batch));
+                batchAccumulator.add(executeBatch(handle, batch));
                 batch = handle.prepareBatch(sql);
                 populateSqlObjectData((ConcreteStatementContext) batch.getContext());
                 applyCustomizers(batch, args);
@@ -204,50 +185,28 @@ class BatchHandler extends CustomizingStatementHandler
         }
 
         //execute the rest
-        rs_parts.add(executeBatch(handle, batch));
+        batchAccumulator.add(executeBatch(handle, batch));
 
-        // combine results
-        int end_size = 0;
-        for (int[] rs_part : rs_parts) {
-            end_size += rs_part.length;
-        }
-        int[] rs = new int[end_size];
-        int offset = 0;
-        for (int[] rs_part : rs_parts) {
-            System.arraycopy(rs_part, 0, rs, offset, rs_part.length);
-            offset += rs_part.length;
-        }
-
-        return rs;
+        return batchAccumulator.getResult();
     }
 
-    private int[] executeBatch(final Handle handle, final PreparedBatch batch)
+    private Object executeBatch(final Handle handle, final PreparedBatch batch)
     {
         if (!handle.isInTransaction() && transactional) {
             // it is safe to use same prepared batch as the inTransaction passes in the same
             // Handle instance.
-            return handle.inTransaction(new TransactionCallback<int[]>()
+            return handle.inTransaction(new TransactionCallback<Object>()
             {
                 @Override
-                public int[] inTransaction(Handle conn, TransactionStatus status) throws Exception
+                public Object inTransaction(Handle conn, TransactionStatus status) throws Exception
                 {
-                    return returner.value(batch);
+                    return batchReturner.executeBatch(batch);
                 }
             });
         }
         else {
-            return returner.value(batch);
+            return batchReturner.executeBatch(batch);
         }
-    }
-
-    private static int[] toPrimitiveArray(List<Integer> list)
-    {
-        int[] array = new int[list.size()];
-        for (int i = 0; i < list.size(); i++) {
-            array[i] = list.get(i);
-        }
-
-        return array;
     }
 
     private static Object[] next(List<Iterator> args)
@@ -262,11 +221,6 @@ class BatchHandler extends CustomizingStatementHandler
             }
         }
         return rs.toArray();
-    }
-
-    private interface Returner
-    {
-        int[] value(PreparedBatch batch);
     }
 
     private interface ChunkSizeFunction
@@ -305,7 +259,7 @@ class BatchHandler extends CustomizingStatementHandler
     }
 
     private static boolean returnTypeIsValid(Class<?> type) {
-        if (type.equals(Void.TYPE) || type.isArray() && type.getComponentType().equals(Integer.TYPE)) {
+        if (type.equals(Void.TYPE) || type.isArray() && (type.getComponentType().equals(Integer.TYPE) || type.getComponentType().equals(Long.TYPE))) {
             return true;
         }
 

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/BatchHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/BatchHandler.java
@@ -35,6 +35,7 @@ import org.skife.jdbi.v2.sqlobject.batch.BatchAccumulator;
 import org.skife.jdbi.v2.sqlobject.batch.BatchReturner;
 import org.skife.jdbi.v2.sqlobject.customizers.BatchChunkSize;
 
+import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.classmate.members.ResolvedMethod;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -62,12 +63,13 @@ class BatchHandler extends CustomizingStatementHandler
 
     private static BatchReturner<?> newBatchReturner(ResolvedMethod method) {
         GetGeneratedKeys getGeneratedKeys = method.getRawMember().getAnnotation(GetGeneratedKeys.class);
+        ResolvedType returnType = method.getReturnType();
         if (getGeneratedKeys == null) {
             return BatchReturner.newIntArrayReturner();
-        } else if (method.getReturnType().getErasedType().equals(int[].class)) {
-            return BatchReturner.newGeneratedIntReturner(getGeneratedKeys.columnName());
-        } else {
+        } else if (returnType != null && returnType.getErasedType().equals(long[].class)) {
             return BatchReturner.newGeneratedLongReturner(getGeneratedKeys.columnName());
+        } else {
+            return BatchReturner.newGeneratedIntReturner(getGeneratedKeys.columnName());
         }
     }
 

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/batch/BatchAccumulator.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/batch/BatchAccumulator.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2.sqlobject.batch;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class BatchAccumulator {
+  protected final List<Object> values = new ArrayList<Object>();
+
+  public void add(Object value) {
+    values.add(value);
+  }
+
+  public abstract Object getResult();
+
+  static class IntArrayAccumulator extends BatchAccumulator {
+
+    @Override
+    public int[] getResult() {
+      int length = 0;
+      for (Object value : values) {
+        if (value instanceof int[]) {
+          length += ((int []) value).length;
+        } else {
+          throw new IllegalStateException("non-int[] value in result set: " + value);
+        }
+      }
+
+      int[] result = new int[length];
+      int offset = 0;
+      for (Object value : values) {
+        int[] valueArray = (int[]) value;
+        System.arraycopy(valueArray, 0, result, offset, valueArray.length);
+        offset += valueArray.length;
+      }
+      return result;
+    }
+  }
+
+  private abstract static class ListAccumulator extends BatchAccumulator {
+
+    @Override
+    public void add(Object value) {
+      if (value instanceof List) {
+        values.addAll((List<?>) value);
+      } else {
+        throw new IllegalArgumentException("Expected List, got " + value);
+      }
+    }
+  }
+
+  static class IntListAccumulator extends ListAccumulator {
+
+    @Override
+    public int[] getResult() {
+      int[] result = new int[values.size()];
+
+      int i = 0;
+      for (Object value : values) {
+        if (value instanceof Integer) {
+          result[i++] = (Integer) value;
+        } else {
+          throw new IllegalStateException("non-Integer value in result set: " + value);
+        }
+      }
+
+      return result;
+    }
+  }
+
+  static class LongListAccumulator extends ListAccumulator {
+
+    @Override
+    public long[] getResult() {
+      long[] result = new long[values.size()];
+
+      int i = 0;
+      for (Object value : values) {
+        if (value instanceof Long) {
+          result[i++] = (Long) value;
+        } else {
+          throw new IllegalStateException("non-Long value in result set: " + value);
+        }
+      }
+
+      return result;
+    }
+  }
+}

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/batch/BatchReturner.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/batch/BatchReturner.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.skife.jdbi.v2.sqlobject.batch;
+
+import java.util.List;
+
+import org.skife.jdbi.v2.PreparedBatch;
+import org.skife.jdbi.v2.sqlobject.batch.BatchAccumulator.IntArrayAccumulator;
+import org.skife.jdbi.v2.sqlobject.batch.BatchAccumulator.IntListAccumulator;
+import org.skife.jdbi.v2.sqlobject.batch.BatchAccumulator.LongListAccumulator;
+import org.skife.jdbi.v2.tweak.ResultColumnMapper;
+import org.skife.jdbi.v2.util.IntegerColumnMapper;
+import org.skife.jdbi.v2.util.LongColumnMapper;
+
+public abstract class BatchReturner<T> {
+
+  public abstract T executeBatch(PreparedBatch batch);
+
+  public abstract BatchAccumulator newAccumulator();
+
+  public static BatchReturner<int[]> newIntArrayReturner() {
+    return new BatchReturner<int[]>() {
+      @Override
+      public int[] executeBatch(PreparedBatch batch) {
+        return batch.execute();
+      }
+
+      @Override
+      public BatchAccumulator newAccumulator() {
+        return new IntArrayAccumulator();
+      }
+    };
+  }
+
+  public static BatchReturner<List<Integer>> newGeneratedIntReturner(String columnName) {
+    return new GeneratedKeysReturner<Integer>(IntegerColumnMapper.PRIMITIVE, columnName) {
+      @Override
+      public BatchAccumulator newAccumulator() {
+        return new IntListAccumulator();
+      }
+    };
+  }
+
+  public static BatchReturner<List<Long>> newGeneratedLongReturner(String columnName) {
+    return new GeneratedKeysReturner<Long>(LongColumnMapper.PRIMITIVE, columnName) {
+      @Override
+      public BatchAccumulator newAccumulator() {
+        return new LongListAccumulator();
+      }
+    };
+  }
+
+  private abstract static class GeneratedKeysReturner<T> extends BatchReturner<List<T>> {
+    private final ResultColumnMapper<T> resultColumnMapper;
+    private final String columnName;
+
+    GeneratedKeysReturner(
+        ResultColumnMapper<T> resultColumnMapper,
+        String columnName
+    ) {
+      this.resultColumnMapper = resultColumnMapper;
+      this.columnName = columnName;
+    }
+
+    public List<T> executeBatch(PreparedBatch batch) {
+      if (columnName.isEmpty()) {
+        return batch.executeAndGenerateKeys(resultColumnMapper).list();
+      } else {
+        return batch.executeAndGenerateKeys(resultColumnMapper, columnName).list();
+      }
+    }
+  }
+}

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeysHsqlDb.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestGetGeneratedKeysHsqlDb.java
@@ -50,7 +50,11 @@ public class TestGetGeneratedKeysHsqlDb {
 
         @SqlBatch("insert into something (name) values (:it)")
         @GetGeneratedKeys
-        public int[] insert(@Bind List<String> names);
+        public int[] insertReturnIntArray(@Bind List<String> names);
+
+        @SqlBatch("insert into something (name) values (:it)")
+        @GetGeneratedKeys
+        public long[] insertReturnLongArray(@Bind List<String> names);
 
         @SqlQuery("select name from something where id = :it")
         public String findNameById(@Bind long id);
@@ -74,7 +78,7 @@ public class TestGetGeneratedKeysHsqlDb {
     {
         DAO dao = dbi.open(DAO.class);
 
-        int[] ids = dao.insert(Arrays.asList("Burt", "Macklin"));
+        int[] ids = dao.insertReturnIntArray(Arrays.asList("Burt", "Macklin"));
 
         assertThat(dao.findNameById(ids[0]), equalTo("Burt"));
         assertThat(dao.findNameById(ids[1]), equalTo("Macklin"));
@@ -82,4 +86,17 @@ public class TestGetGeneratedKeysHsqlDb {
         dao.close();
     }
 
+
+    @Test
+    public void testBatchWithLongArray() throws Exception
+    {
+        DAO dao = dbi.open(DAO.class);
+
+        long[] ids = dao.insertReturnLongArray(Arrays.asList("Burt", "Macklin"));
+
+        assertThat(dao.findNameById(ids[0]), equalTo("Burt"));
+        assertThat(dao.findNameById(ids[1]), equalTo("Macklin"));
+
+        dao.close();
+    }
 }


### PR DESCRIPTION
This allows sql batches to return `long[]` of generated ids.

This is a version of https://github.com/HubSpot/jdbi/pull/11 that adds more abstractions to hopefully make the code a little easier to understand at a glance.

@NickDelfino @jhaber @kmclarnon @Xcelled @bwarminski 