### PR TITLE
Add support for returning a long from SqlUpdate 

### DIFF
--- a/src/main/java/org/skife/jdbi/v2/Update.java
+++ b/src/main/java/org/skife/jdbi/v2/Update.java
@@ -67,6 +67,26 @@ public class Update extends SQLStatement<Update>
     }
 
     /**
+     * Execute the statement for a large number of affected rows
+     * @return the number of rows modified
+     */
+    public long executeLarge()
+    {
+        try {
+            return this.internalExecute(new QueryResultMunger<Long>() {
+                @Override
+                public Long munge(Statement results) throws SQLException
+                {
+                    return results.getLargeUpdateCount();
+                }
+            });
+        }
+        finally {
+            cleanup();
+        }
+    }
+
+    /**
      * Execute the statement and returns any auto-generated keys. This requires the JDBC driver to support
      * the {@link Statement#getGeneratedKeys()} method.
      * @param mapper the mapper to generate the resulting key object

--- a/src/main/java/org/skife/jdbi/v2/Update.java
+++ b/src/main/java/org/skife/jdbi/v2/Update.java
@@ -13,13 +13,7 @@
  */
 package org.skife.jdbi.v2;
 
-import org.skife.jdbi.v2.tweak.ResultColumnMapper;
-import org.skife.jdbi.v2.tweak.ResultSetMapper;
-import org.skife.jdbi.v2.tweak.SQLLog;
-import org.skife.jdbi.v2.tweak.StatementBuilder;
-import org.skife.jdbi.v2.tweak.StatementCustomizer;
-import org.skife.jdbi.v2.tweak.StatementLocator;
-import org.skife.jdbi.v2.tweak.StatementRewriter;
+import org.skife.jdbi.v2.tweak.*;
 import org.skife.jdbi.v2.util.SingleColumnMapper;
 
 import java.sql.SQLException;
@@ -67,10 +61,10 @@ public class Update extends SQLStatement<Update>
     }
 
     /**
-     * Execute the statement for a large number of affected rows
+     * Execute the statement when the count of affected rows could exceed INT_MAX, requiring a long
      * @return the number of rows modified
      */
-    public long executeLarge()
+    public long executeReturningLong()
     {
         try {
             return this.internalExecute(new QueryResultMunger<Long>() {

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/UpdateHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/UpdateHandler.java
@@ -68,7 +68,7 @@ class UpdateHandler extends CustomizingStatementHandler
                     @Override
                     public Object value(Update update, HandleDing baton)
                     {
-                        return update.executeLarge();
+                        return update.executeReturningLong();
                     }
                 };
             } else {

--- a/src/main/java/org/skife/jdbi/v2/sqlobject/UpdateHandler.java
+++ b/src/main/java/org/skife/jdbi/v2/sqlobject/UpdateHandler.java
@@ -60,14 +60,25 @@ class UpdateHandler extends CustomizingStatementHandler
             };
         }
         else {
-            this.returner = new Returner()
-            {
-                @Override
-                public Object value(Update update, HandleDing baton)
+            if (method.getReturnType() != null && (
+                    method.getReturnType().getErasedType().equals(Long.class) ||
+                            method.getReturnType().getErasedType().equals(Long.TYPE))) {
+                this.returner = new Returner()
                 {
-                    return update.execute();
-                }
-            };
+                    @Override
+                    public Object value(Update update, HandleDing baton)
+                    {
+                        return update.executeLarge();
+                    }
+                };
+            } else {
+                this.returner = new Returner() {
+                    @Override
+                    public Object value(Update update, HandleDing baton) {
+                        return update.execute();
+                    }
+                };
+            }
         }
     }
 

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestStatements.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestStatements.java
@@ -82,6 +82,31 @@ public class TestStatements
     }
 
     @Test
+    public void testUpdate() throws Exception
+    {
+        Inserter i = SqlObjectBuilder.open(dbi, Inserter.class);
+        i.insertWithVoidReturn(1, "Danny");
+        Updater u = SqlObjectBuilder.open(dbi, Updater.class);
+
+        int updated = u.update("Diego");
+
+        assertEquals(updated, 1);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUpdateLarge() throws Exception
+    {
+        Inserter i = SqlObjectBuilder.open(dbi, Inserter.class);
+        i.insertWithVoidReturn(1, "Danny");
+        Updater u = SqlObjectBuilder.open(dbi, Updater.class);
+
+        u.updateLarge("Diego");
+
+        // Exception should be thrown because default impl of java.sql.Statement
+        // which is used in these tests does not support getLargeUpdateCount
+    }
+
+    @Test
     public void testDoubleArgumentBind() throws Exception
     {
         Doubler d = dbi.open(Doubler.class);
@@ -95,6 +120,15 @@ public class TestStatements
 
         @SqlUpdate("insert into something (id, name) values (:id, :name)")
         public void insertWithVoidReturn(@Bind("id") long id, @Bind("name") String name);
+    }
+
+    public static interface Updater extends CloseMe
+    {
+        @SqlUpdate("update something set name = :name")
+        public int update(@Bind("name") String name);
+
+        @SqlUpdate("update something set name = :name")
+        public long updateLarge(@Bind("name") String name);
     }
 
     public interface Doubler

--- a/src/test/java/org/skife/jdbi/v2/sqlobject/TestStatements.java
+++ b/src/test/java/org/skife/jdbi/v2/sqlobject/TestStatements.java
@@ -94,13 +94,13 @@ public class TestStatements
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateLarge() throws Exception
+    public void testUpdateReturningLong() throws Exception
     {
         Inserter i = SqlObjectBuilder.open(dbi, Inserter.class);
         i.insertWithVoidReturn(1, "Danny");
         Updater u = SqlObjectBuilder.open(dbi, Updater.class);
 
-        u.updateLarge("Diego");
+        u.updateReturningLong("Diego");
 
         // Exception should be thrown because default impl of java.sql.Statement
         // which is used in these tests does not support getLargeUpdateCount
@@ -128,7 +128,7 @@ public class TestStatements
         public int update(@Bind("name") String name);
 
         @SqlUpdate("update something set name = :name")
-        public long updateLarge(@Bind("name") String name);
+        public long updateReturningLong(@Bind("name") String name);
     }
 
     public interface Doubler


### PR DESCRIPTION
Currently `@SqlUpdate` annotated methods cannot return more than INT_MAX affected rows even if they declare their return type as `long`. This is because internally JDBI is calling `getUpdateCount` which returns an `int`. Switching to `getLargeUpdateCount` allows it to retrieve a `long`. Testing locally this seems to fix the problem with the Snowflake JDBC driver, at a minimum.

I tried to keep the effect of this change limited. Switching to `long` everywhere would have broken existing APIs and increased the chance of unintentional effects. By checking the return type in `UpdateHandler` I aim to allow users to opt in to this behaviour. Although I expect quite a few users are already declaring `long` without realising that it previously had no effect, so when this is merged they will suddenly switch to the new codepath.